### PR TITLE
Fixed directory creation issue

### DIFF
--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -28,6 +28,7 @@ namespace OCA\Files_External_Ethswarm\Db;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\IDBConnection;
+use OCP\Files\IMimeTypeLoader;
 
 /**
  * @template-extends QBMapper<SwarmFile>
@@ -86,6 +87,16 @@ class SwarmFileMapper extends QBMapper {
 			->where($qb->expr()->eq('name', $qb->createNamedParameter($name, $qb::PARAM_STR)))
 			->andWhere($qb->expr()->eq('storage', $qb->createNamedParameter($storage, $qb::PARAM_INT)));
 		return count($this->findEntities($select));
+	}
+
+	public function createDirectory(string $path, int $storage): SwarmFile {
+		$swarm = new SwarmFile();
+		$swarm->setName($path);
+		$swarm->setMimetype(\OC::$server->get(IMimeTypeLoader::class)->getId("httpd/unix-directory"));
+		$swarm->setSize(1);
+		$swarm->setStorageMtime(time());
+		$swarm->setStorage($storage);
+		return $this->insert($swarm);
 	}
 
 	public function createFile(array $filearray): SwarmFile {

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -160,8 +160,9 @@ class BeeSwarm extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function mkdir($path) {
-	 	return true;
+	public function mkdir($path): bool {
+		$this->filemapper->createDirectory($path, $this->storageId);
+		return true;
 	}
 
 	public function rmdir($path) {
@@ -178,20 +179,26 @@ class BeeSwarm extends \OC\Files\Storage\Common {
 	}
 
 	public function opendir($path) {
-	 	return false;
+	 	return true;
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function is_dir($path) {
-		return $this->file_exists($path) == false;
+		$data = $this->getMetaData($path);
+		if ($data['mimetype'] === 'httpd/unix-directory') {
+			return true;
+		}
 	}
 	/**
 	 * @return bool
 	 */
 	public function is_file($path) {
-		return $this->file_exists($path) == true;
+		$data = $this->getMetaData($path);
+		if ($data['mimetype'] === 'httpd/unix-directory') {
+			return false;
+		}
 	}
 
 	public function filetype($path) {
@@ -239,6 +246,7 @@ class BeeSwarm extends \OC\Files\Storage\Common {
 	}
 
 	public function verifyPath($path, $fileName) {
+
 	}
 
 	/**
@@ -309,14 +317,15 @@ class BeeSwarm extends \OC\Files\Storage\Common {
 	/* Enabling this function causes a fatal exception "Call to a member function getId() on null /var/www/html/lib/private/Files/Mount/MountPoint.php - line 276: OC\Files\Cache\Wrapper\CacheWrapper->getId("")
 	public function getCache($path = '', $storage = null)
 	{
-		\OC::$server->getLogger()->warning("\\apps\\nextcloud-swarm-plugin\\lib\\Storage\\BeeSwarm.php-getCache(): path=" . $path);
+
 	}
 	*/
+	/*
+	public function getDirectoryContent($directory): \Traversable {
+		return new \EmptyIterator();
+	}*/
 
-	// public function getDirectoryContent($directory): \Traversable {
-	// }
-
-		/**
+/**
 	 * @param string $path
 	 * @return array|null
 	 */
@@ -358,7 +367,7 @@ class BeeSwarm extends \OC\Files\Storage\Common {
             $data['size'] = $swarmFile->getSize();
             $data['etag'] = uniqid();
 			$data['swarm_ref'] = $swarmFile->getSwarmReference();
-        }
+		}
 	 	return $data;
 	}
 


### PR DESCRIPTION
The issue was twofold, and related to the assumptions made around directories in the plugin. As it turns out, when creating a directory in Nextcloud 28, Sabre contacts our plugin in two distinct places: `getMetaData` and `file_exists`.
While the `getMetaData` call succeeds and populates the `MKCOL` response, the existence of an `oc-fileid` HTTP header depends on `file_exists`, which will always return false for directories.

This fix involves adding directories as files without Swarm-specific metadata to the Swarm file mapping database. This approach may introduce incompatibilities, and require a Migration step to be devised to populate the table and get rid of the cache-based assumption.

This commit does not remove the cache-based assumption so as to not break existing file databases.
