### PR TITLE
fix(files_scan): Fixed disappearing files issue

### DIFF
--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -111,15 +111,18 @@ class SwarmFileMapper extends QBMapper {
 		return $this->insert($swarm);
 	}
 
-	public function getPathTree(string $path1, int $storage): array {
+	public function getPathTree(string $path1, int $storage, bool $incSelf = true): array {
 		// Get files from directory tree based on path parameter
 		$dir = array();
-		try {
-			array_push($dir, $this->find($path1, $storage));
-		} catch (DoesNotExistException $e) {
+		if ($incSelf) {
+			try {
+				array_push($dir, $this->find($path1, $storage));
+			} catch (DoesNotExistException $e) {
+			}
 		}
 
-		$path1 .= '/';
+		if ($path1 !== '')
+			$path1 .= '/';
 
 		$qb = $this->db->getQueryBuilder();
 		$select = $qb
@@ -127,8 +130,7 @@ class SwarmFileMapper extends QBMapper {
 			->from($this->getTableName())
 			->where($qb->expr()->like('name', $qb->createNamedParameter($this->db->escapeLikeParameter($path1) . '%', $qb::PARAM_STR)))
 			->andWhere($qb->expr()->eq('storage', $qb->createNamedParameter($storage, $qb::PARAM_INT)));
-		array_merge($dir, $this->findEntities($select));
-		return $dir;
+		return array_merge($dir, $this->findEntities($select));
 	}
 
 	public function updatePath(string $path1, string $path2, int $storage): int {

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -226,6 +226,7 @@ class BeeSwarm extends Common
 		if ($data['mimetype'] === 'httpd/unix-directory') {
 			return false;
 		}
+		return true;
 	}
 
 	public function filetype($path)
@@ -373,10 +374,6 @@ class BeeSwarm extends Common
 
 	}
 	*/
-	/*
-	public function getDirectoryContent($directory): \Traversable {
-		return new \EmptyIterator();
-	}*/
 
 	/**
 	 * @param string $path
@@ -426,6 +423,14 @@ class BeeSwarm extends Common
 			$data['swarm_ref'] = $swarmFile->getSwarmReference();
 		}
 		return $data;
+	}
+
+	public function getDirectoryContent($path): \Traversable
+	{
+		$rows = $this->filemapper->getPathTree($path, $this->storageId, false);
+		$content = array_map(fn($val) => $this->getMetaData($val->getName()), $rows);
+
+		return new \ArrayIterator($content);
 	}
 
 	protected function toTempFile($source)


### PR DESCRIPTION
The missing getDirectoryContent() method was preventing the indexer from
discovering files within the root folder, so it didn't bother and marked
everything as nonexistent.

This commit also includes a fix for files disappearing when the parent
folder is renamed.

This fix supersedes #64
