### PR TITLE
fix(files-scan): Fixed file indexing for subfolder

### DIFF
--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -111,7 +111,7 @@ class SwarmFileMapper extends QBMapper {
 		return $this->insert($swarm);
 	}
 
-	public function getPathTree(string $path1, int $storage, bool $incSelf = true): array {
+	public function getPathTree(string $path1, int $storage, bool $incSelf = true, bool $recursive = true): array {
 		// Get files from directory tree based on path parameter
 		$dir = array();
 		if ($incSelf) {
@@ -130,6 +130,8 @@ class SwarmFileMapper extends QBMapper {
 			->from($this->getTableName())
 			->where($qb->expr()->like('name', $qb->createNamedParameter($this->db->escapeLikeParameter($path1) . '%', $qb::PARAM_STR)))
 			->andWhere($qb->expr()->eq('storage', $qb->createNamedParameter($storage, $qb::PARAM_INT)));
+		if (!$recursive)
+			$select->andWhere($qb->expr()->notLike('name', $qb->createNamedParameter($this->db->escapeLikeParameter($path1) . '%/%', $qb::PARAM_STR)));
 		return array_merge($dir, $this->findEntities($select));
 	}
 

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -427,7 +427,9 @@ class BeeSwarm extends Common
 
 	public function getDirectoryContent($path): \Traversable
 	{
-		$rows = $this->filemapper->getPathTree($path, $this->storageId, false);
+		$rows = $this->filemapper->getPathTree($path, $this->storageId,
+		                                       incSelf: false,
+		                                       recursive: false);
 		$content = array_map(fn($val) => $this->getMetaData($val->getName()), $rows);
 
 		return new \ArrayIterator($content);


### PR DESCRIPTION
The new issue causing files to disappear turned out to be due to including files from subfolders in a parent folder's readout.

Running `files:scan` should repair any affected filesystems as again, the `oc_files_swarm` database should be untouched
