### PR TITLE
 BUG - Wrong formating on md files

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,7 +63,7 @@ Experience the future of data storage with 5GB of free, decentralized storage on
 
 [Get your free licence here!](https://metaprovide.org/hejbit/start) .
     ]]></description>
-    <version>0.5.4</version>
+    <version>0.5.6</version>
     <licence>agpl</licence>
     <author>MetaProvide</author>
     <namespace>Files_External_Ethswarm</namespace>

--- a/lib/Migration/Version0003Date202401101430.php
+++ b/lib/Migration/Version0003Date202401101430.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022, MetaProvide Holding EKF
+ *
+ * @author Ron Trevor <ecoron@proton.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files_External_Ethswarm\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\DB\Types;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+
+class Version0003Date202401101430 extends SimpleMigrationStep {
+
+	private $db;
+
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$qb = $this->db->getQueryBuilder();
+
+		$updateQb = $this->db->getQueryBuilder();
+		$updateQb->update('files_swarm')
+			->set('mimetype', $updateQb->createNamedParameter(4, IQueryBuilder::PARAM_INT))
+			->where($updateQb->expr()->like('name', $updateQb->createNamedParameter('%.md')))
+			->executeStatement();
+
+	}}

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -452,6 +452,10 @@ class BeeSwarm extends Common
 		$tmpFilesize = (file_exists($tmpFile) ? filesize($tmpFile) : -1);
 		$mimetype = mime_content_type($tmpFile);
 
+		if (str_ends_with(strtolower($path),'.md' )){
+			$mimetype = "text/markdown";
+		}
+
 		try {
 			$result = $this->uploadStream($path, $tmpFile, $mimetype, $tmpFilesize);
 			$reference = (isset($result["reference"]) ? $result['reference'] : null);


### PR DESCRIPTION
Don't understand why using the function mime_content_type on the tmp file doesn't work (maybe because it loses the filename), so I check if the file has .md on the end, if it has .md on the end forces the mimetype to "text/markdown".

It's possible to add a migration step to update all the references that have .md on the end to the mimetype = 4 if we want to fix the problem in previous uploaded files.