### PR TITLE
Feature/#833 disconnect reconnect storage

### DIFF
--- a/lib/Db/SwarmFile.php
+++ b/lib/Db/SwarmFile.php
@@ -48,6 +48,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int|null getStorage()
  * @method void setVisibility(int $visibility)
  * @method int getVisibility()
+ * @method void setToken(string $token)
+ * @method int getToken()
  */
 class SwarmFile extends Entity {
 
@@ -81,6 +83,9 @@ class SwarmFile extends Entity {
 	/** @var int */
 	protected $visibility;
 
+	/** @var string */
+	protected $token;
+
 	public function __construct() {
 		$this->addType('fileid', 'int');
 		$this->addType('name', 'string');
@@ -92,5 +97,6 @@ class SwarmFile extends Entity {
 		$this->addType('encryptionkey', 'string');
 		$this->addType('storage', 'int');
 		$this->addType('visibility', 'int');
+		$this->addType('token', 'string');
 	}
 }

--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -108,6 +108,7 @@ class SwarmFileMapper extends QBMapper {
 		$swarm->setSize($filearray["size"]);
 		$swarm->setStorageMtime($filearray["storage_mtime"]);
 		$swarm->setStorage($filearray["storage"]);
+		$swarm->setToken($filearray["token"]);
 		return $this->insert($swarm);
 	}
 
@@ -144,6 +145,31 @@ class SwarmFileMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('storage', $qb->createNamedParameter($storage, $qb::PARAM_INT)));
 		$sql = $qb->getSQL();
 		return $qb->executeStatement();
+	}
+
+	/**
+	 * @return SwarmFile[]
+	 */
+	public function findAllWithToken(string $token): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb
+			->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)));
+
+		return $this->findEntities($select);
+	}
+
+
+	public function updateStorageIds(string $token,string $storageid): int {
+
+		foreach ($this->findAllWithToken($token) as $swarmFile) {
+			$swarmFile->setStorage($storageid);
+			$this->update($swarmFile);
+		};
+
+		return 1;
 	}
 
 }

--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -89,13 +89,14 @@ class SwarmFileMapper extends QBMapper {
 		return count($this->findEntities($select));
 	}
 
-	public function createDirectory(string $path, int $storage): SwarmFile {
+	public function createDirectory(string $path, int $storage, string $token): SwarmFile {
 		$swarm = new SwarmFile();
 		$swarm->setName($path);
 		$swarm->setMimetype(\OC::$server->get(IMimeTypeLoader::class)->getId("httpd/unix-directory"));
 		$swarm->setSize(1);
 		$swarm->setStorageMtime(time());
 		$swarm->setStorage($storage);
+		$swarm->setToken($token);
 		return $this->insert($swarm);
 	}
 

--- a/lib/Migration/Version0005Date202411081430.php
+++ b/lib/Migration/Version0005Date202411081430.php
@@ -60,7 +60,7 @@ class Version0005Date202411081430 extends SimpleMigrationStep {
 				'length' => 64,
 				'default' => 'none',
 			]);
-			$table->addIndex(['token'], 'token_index');
+			$table->addIndex(['token'], 'hejbit_token_index');
 
 		}
 		return $schema;

--- a/lib/Migration/Version0005Date202411081430.php
+++ b/lib/Migration/Version0005Date202411081430.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022, MetaProvide Holding EKF
+ *
+ * @author Ron Trevor <ecoron@proton.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files_External_Ethswarm\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\DB\Types;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class Version0005Date202411081430 extends SimpleMigrationStep {
+	private $db;
+	public const _TABLENAMEREF = "files_swarm_tokens";
+
+
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable(self::_TABLENAMEREF)) {
+			$table = $schema->createTable(self::_TABLENAMEREF);
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('files_swarm_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('token_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['token_id'], 'token_index');
+		}
+		return $schema;
+
+
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$gqbNI = $this->db->getQueryBuilder();
+		$gqbFI = $this->db->getQueryBuilder();
+		$iqb = $this->db->getQueryBuilder();
+
+		// Get all the numeric_id's of the swarm storages
+
+		$resultNI = $gqbNI->select('numeric_id', 'id')
+		   ->from('storages')
+		   ->where($gqbNI->expr()->like('id', $gqbNI->createNamedParameter('ethswarm::%')))
+		   ->executeQuery();
+
+		while ($row = $resultNI->fetch()) {
+			// Get all the files on each swarm storage
+			$numeric_id = $row['numeric_id'];
+			$token_id = $row['id'];
+
+			$resultFileIds = $gqbFI->select('id')
+			->from('files_swarm')
+			->where($gqbFI->expr()->eq('storage', $gqbFI->createNamedParameter($numeric_id)))
+			->executeQuery();
+
+			while ($row = $resultFileIds->fetch()) {
+				$file_id = $row['id'];
+				// Insert the file_id and token_id into the new table
+				$result = $iqb->insert(self::_TABLENAMEREF)
+					->values([
+						'files_swarm_id' => $iqb->createNamedParameter($file_id),
+						'token_id' => $iqb->createNamedParameter($token_id)
+					])
+					->executeStatement();
+			}
+
+		}
+	}}

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -144,9 +144,37 @@ class BeeSwarm extends Common
 	 */
 	public function test(): bool
 	{
+		if (!$this->checkConnection()){
+			return false;
+		}
+
 		$this->filemapper->updateStorageIds($this->token,$this->storageId);
+		$this->add_rootfolder_cache();
 		$this->add_token_files_cache();
-		return $this->checkConnection();
+		return true;
+	}
+
+	public function add_rootfolder_cache(): bool
+	{
+
+		$fileData = [
+			'storage' => $this->storageId,
+			'path' => '',
+			'path_hash' => md5(''),
+			'name' => '',
+			'mimetype' => 'httpd/unix-directory',
+			'size' => 1,
+			'etag' => uniqid(),
+			'storage_mtime' => time(),
+			// 2024-11-14 - We still don't support edit, so file is never updated.
+			'mtime' => time(),
+			'permissions' => (Constants::PERMISSION_ALL - Constants::PERMISSION_DELETE),
+			'parent' => -1,
+		];
+
+
+		$fileId = $this->cacheHandler->put($fileData['path'], $fileData);
+		return true;
 	}
 
 	/**

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -203,7 +203,7 @@ class BeeSwarm extends Common
 
 	public function mkdir($path): bool
 	{
-		$this->filemapper->createDirectory($path, $this->storageId);
+		$this->filemapper->createDirectory($path, $this->storageId,$this->token);
 		return true;
 	}
 

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -80,6 +80,9 @@ class BeeSwarm extends Common
 	/** @var string */
 	protected string $id;
 
+	/** @var string */
+	private string $token;
+
 	public function __construct($params)
 	{
 		/** @var IL10NFactory $l10nFactory */
@@ -91,6 +94,7 @@ class BeeSwarm extends Common
 		$this->parseParams($params);
 		$this->id = 'ethswarm::'.$this->access_key;
 		$this->storageId = $this->getStorageCache()->getNumericId();
+		$this->token = $this->getStorageCache()->getStorageId($this->storageId);
 
 		// Load handlers
 		$dbConnection = \OC::$server->get(IDBConnection::class);
@@ -139,6 +143,7 @@ class BeeSwarm extends Common
 	 */
 	public function test(): bool
 	{
+		$this->filemapper->updateStorageIds($this->token,$this->storageId);
 		return $this->checkConnection();
 	}
 
@@ -497,6 +502,7 @@ class BeeSwarm extends Common
 			"etag" => null,
 			"reference" => $reference,
 			"storage" => $this->storageId,
+			"token" => $this->token,
 		];
 		$this->filemapper->createFile($uploadfiles);
 


### PR DESCRIPTION
Solution:

1. Add token to the swarm table
Everytime the storage is tested (click on the check button) the following happen:
1. All files from swarm table are updated with the new storage id (found by token key)
2. Root folder is added to the cache table
3. All files from swarm table are added to the cache table

Possible future improvements - Control the places of execution and how is executed

- Update the storage id on swarm table only the first time the storaged is created 
- Update the cache  only the first time the storaged is created 