### PR TITLE
Root (mount) folder $filename === "" doesn't exist on swarm table

### DIFF
--- a/lib/Sabre/PropfindPlugin.php
+++ b/lib/Sabre/PropfindPlugin.php
@@ -89,6 +89,14 @@ class PropfindPlugin extends ServerPlugin {
 			}
 			$class = $this->EthswarmService;
 
+			$propFind->handle(self::ETHSWARM_NODE, function () use ($class, $storageid, $filename)
+			{
+					return "true";
+			});
+			if ($filename === "") {
+				return "";
+			}
+
 			if($class->getVisiblity($filename, $storageid)==1){
 				$propFind->set("{http://nextcloud.org/ns}hidden","false",200);
 			}
@@ -96,10 +104,7 @@ class PropfindPlugin extends ServerPlugin {
 				$propFind->set("{http://nextcloud.org/ns}hidden","true",200);
 			}
 
-			$propFind->handle(self::ETHSWARM_NODE, function () use ($class, $storageid, $filename)
-			{
-					return "true";
-			});
+
 		}
 
 	}


### PR DESCRIPTION
Root (mount) folder $filename === "" doesn't exist on swarm table.

To Test:
Open files app, and files apps should work.



Before the fix:
![image](https://github.com/user-attachments/assets/a2818e1e-939c-445c-ba00-c5d4c7c3a6e1)

After the fix:
![image](https://github.com/user-attachments/assets/3a3ae157-21b3-4dd8-a4a1-459946da1b78)
