### PR TITLE
bugfix: #929 - allow other plugin to handle request

### DIFF
--- a/lib/Sabre/PostPlugin.php
+++ b/lib/Sabre/PostPlugin.php
@@ -9,49 +9,58 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use OCA\Files_External_Ethswarm\Service\EthswarmService;
 
-class PostPlugin extends ServerPlugin {
-    /** @var Server */
-    private $server;
+class PostPlugin extends ServerPlugin
+{
+	/** @var Server */
+	private $server;
 
-    /** @var EthswarmService */
-    private $EthswarmService;
+	/** @var EthswarmService */
+	private $EthswarmService;
 
-    public function __construct(EthswarmService $service) {
-        $this->EthswarmService = $service;
-    }
+	public function __construct(EthswarmService $service)
+	{
+		$this->EthswarmService = $service;
+	}
 
-    public function initialize(Server $server) {
-        $this->server = $server;
-        $this->server->on('method:POST', [$this, 'httpPost']);
-    }
+	public function initialize(Server $server)
+	{
+		$this->server = $server;
+		$this->server->on('method:POST', [$this, 'httpPost']);
+	}
 
-    public function httpPost(RequestInterface $request, ResponseInterface $response)
-    {
-        $action = $request->getRawServerValue('HTTP_HEJBIT_ACTION') ?? null;
+	public function httpPost(RequestInterface $request, ResponseInterface $response)
+	{
+		$action = $request->getRawServerValue('HTTP_HEJBIT_ACTION') ?? null;
 
-        if ($action === 'unview') {
-            $path = $request->getPath();
-            $node = $this->server->tree->getNodeForPath($path);
-            if (($node instanceof \OCA\DAV\Connector\Sabre\File)) {
-                $storageid = $node->getFileInfo()->getStorage()->getCache()->getNumericStorageId();
-           	 	$filename = $node->getFileInfo()->getinternalPath();
-            }
+		if ($action === 'unview') {
+			$path = $request->getPath();
+			$node = $this->server->tree->getNodeForPath($path);
+			if (($node instanceof \OCA\DAV\Connector\Sabre\File)) {
+				$storageid = $node->getFileInfo()->getStorage()->getCache()->getNumericStorageId();
+				$filename = $node->getFileInfo()->getinternalPath();
+			}
 			if (($node instanceof \OCA\DAV\Connector\Sabre\Directory)) {
-                $storageid = $node->getFileInfo()->getStorage()->getCache()->getNumericStorageId();
-           	 	$filename = $node->getFileInfo()->getinternalPath();
-            }
+				$storageid = $node->getFileInfo()->getStorage()->getCache()->getNumericStorageId();
+				$filename = $node->getFileInfo()->getinternalPath();
+			}
 
-            $class = $this->EthswarmService;
+			$class = $this->EthswarmService;
 
-            $class->setVisiblity($filename, $storageid, 0);
+			$class->setVisiblity($filename, $storageid, 0);
 
-            $response->setStatus(200);
-            $response->setHeader('Content-Length', '0');
+			$response->setStatus(200);
+			$response->setHeader('Content-Length', '0');
 
-            return false;
-        } else {
+			return false;
+		}
+        // No Hejbit-action, allow other plugins to handle the request
+        else if ($action === null) {
+            return true;
+        }
+        // Invalid Hejbit-action, throw exception
+        else {
             $exMessage = 'There was no plugin in the system that was willing to handle a POST method with this action > '.$action.'.';
             throw new \Sabre\DAV\Exception\NotImplemented($exMessage);
         }
-    }
+	}
 }


### PR DESCRIPTION
This fixes the comments on files not working.


## To test
- Before checkout this branch. Try making a comment on any file (HejBit or normal nextcloud file). Before this fix the result is a never ending load spinner on file icon and/or comment not appearing. 🐞 

- Checkout this branch. Try again and hopefully you will see the comment appearing and no load spinner on file icon. ✅ 
