### PR TITLE
Release 0.5.8: PRs #89, #90

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,7 +63,7 @@ Experience the future of data storage with 5GB of free, decentralized storage on
 
 [Get your free licence here!](https://metaprovide.org/hejbit/start) .
     ]]></description>
-    <version>0.5.7</version>
+    <version>0.5.8</version>
     <licence>agpl</licence>
     <author>MetaProvide</author>
     <namespace>Files_External_Ethswarm</namespace>

--- a/lib/Migration/Version0003Date202401101430.php
+++ b/lib/Migration/Version0003Date202401101430.php
@@ -63,7 +63,6 @@ class Version0003Date202401101430 extends SimpleMigrationStep {
 		$mimetype = 'text/markdown';
 
 		if (version_compare($currentVersion, '0.5.4', '==')) {
-			$qb = $this->db->getQueryBuilder();
 
 			$updateQb = $this->db->getQueryBuilder();
 			$updateQb->update('files_swarm')

--- a/lib/Migration/Version0004Date202410131430.php
+++ b/lib/Migration/Version0004Date202410131430.php
@@ -65,12 +65,14 @@ class Version0004Date202410131430 extends SimpleMigrationStep {
 			$numeric_id = $row['numeric_id'];
 
 			// This is assuming we only have one folder with Hejbit Plug (also true on the previous version of the plugin)
+			$qb = $this->db->getQueryBuilder();
 			$result = $qb->select('mount_id')
 			->from('external_mounts')
 			->where($qb->expr()->eq('storage_backend', $qb->createNamedParameter('files_external_ethswarm')))
 			->executeQuery();
 			$mountid = $result->fetchOne();
 
+			$qb = $this->db->getQueryBuilder();
 			$result = $qb->select('value')
 			->from('external_config','m')
 			->where($qb->expr()->eq('m.mount_id', $qb->createNamedParameter($mountid)))

--- a/lib/Migration/Version0005Date202411081430.php
+++ b/lib/Migration/Version0005Date202411081430.php
@@ -68,10 +68,8 @@ class Version0005Date202411081430 extends SimpleMigrationStep {
 
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 		$gqbNI = $this->db->getQueryBuilder();
-		$updateQb = $this->db->getQueryBuilder();
 
 		// Get all the numeric_id's of the swarm storages
-
 		$resultNI = $gqbNI->select('numeric_id', 'id')
 		   ->from('storages')
 		   ->where($gqbNI->expr()->like('id', $gqbNI->createNamedParameter('ethswarm::%')))
@@ -81,6 +79,8 @@ class Version0005Date202411081430 extends SimpleMigrationStep {
 			// Get all the files on each swarm storage
 			$numeric_id = $row['numeric_id'];
 			$token_id = $row['id'];
+
+			$updateQb = $this->db->getQueryBuilder();
 
 			$result = $updateQb->update(self::_TABLENAME)
 			->set('token', $updateQb->createNamedParameter($token_id))

--- a/src/fileactions.js
+++ b/src/fileactions.js
@@ -344,16 +344,14 @@ let previousPathHasSwarm = false;
 subscribe('files:list:updated', (data) => {
 	console.log('Hejbit-files:list:updated');
 
-	if (data.folder.path === '/' && previousPathHasSwarm){
+	if (data.folder?.path === '/' && previousPathHasSwarm){
 		previousPathHasSwarm = false;
 		window.location.reload();
 	}
 
-	const ethswarmNode = data?.contents?.[0]?._data?.attributes?.["ethswarm-node"];
-	if (ethswarmNode !== undefined) {
-		if (ethswarmNode){
-			previousPathHasSwarm = true;
-		}
+	if (data.folder?.attributes["ethswarm-node"]){
+		previousPathHasSwarm = true;
 	}
+
 });
 


### PR DESCRIPTION
# Release 0.5.8

This release includes several critical bug fixes and smaller refactoring.

### Bug Fixes
- [#89] Fixed database migration for Nextcloud 29
  - Resolved SQLSTATE[42601] error in version005 migration
  - Improved database query handling
  - Refactored migration codebase for better maintainability

- [#90] Fixed infinite reload in Recent/Favorites views
  - Corrected property retrieval logic
  - Improved folder handling for Swarm storage files

## Testing Notes
- All changes have been verified in staging environment
- Migration testing performed on Nextcloud 29
- Recent and Favorites views thoroughly tested with Swarm storage files