### PR TITLE
bugfix/correct-install-docker-windows

### DIFF
--- a/cli/dev/windows/README.md
+++ b/cli/dev/windows/README.md
@@ -13,19 +13,20 @@ After running the \\cli\\dev\\windows\\clean.bat and start.bat files (which remo
     or
 
     returns the error "base table or view not found: 1146 Table 'nextcloud.oc_appconfig' doesn't exist":
-  
+
     ![missing tables in nextcloud database](https://github.com/user-attachments/assets/e0c12d9f-427c-45ce-ad5b-4ca675bbe4f3)
 
 -   then check the /config/config.php on the nextcloud container for the following entries:
-    
-    Expected entries in config.php](https://github.com/user-attachments/assets/de1a11a3-3749-469e-9502-3a05fc3e4d9f)
+
+    ![Expected entries in config.php](https://github.com/user-attachments/assets/de1a11a3-3749-469e-9502-3a05fc3e4d9f)
 
     -   If entries are missing (namely that identify the dbhost, dbuser, dbpassword etc), then this could be due to Windows build process not being able to read the \\.env file in the docker-compose.yaml file. The cause of this is unknown. As a workaround, it is good practice to set the default value of environment variables inside the docker-compose (and not rely on the settings defined in \\.env file) eg:
-      
+
     ![NC_VERSION default value is set in the docker-compose](https://github.com/user-attachments/assets/3492e330-081d-41fa-b3ab-b912a17e632a)
 
     -   Note: After any changes to docker-compose, remember to rebuild the docker-compose:
-        -   docker-compose --profile dev up -d --force-recreate --remove-orphans --build
+
+        `docker-compose --profile dev up -d --force-recreate --remove-orphans --build`
 
 ##### Known issue: Local path containimng NC source code has folder(s) with special character.
 

--- a/cli/dev/windows/README.md
+++ b/cli/dev/windows/README.md
@@ -1,0 +1,40 @@
+## Installing docker-compose on Windows
+
+The purpose of this document is to highlight possible issues (and provide solutions and workarounds) when building the docker-compose file on a Windows development environment.
+
+After running the \\cli\\dev\\windows\\clean.bat and start.bat files (which removes any current installation of the hejbit Docker container and builds a new container/volumes), it should be possible to run Nextcloud by opening https://localhost on a browser.
+
+### Known issues
+
+#### Error opening https://localhost
+
+-   If the https://localhost page returns "503 Gateway timeout" error
+
+    or
+
+-   returns the error "base table or view not found: 1146 Table 'nextcloud.oc_appconfig' doesn't exist":
+
+    ![Error: missing tables in nextcloud database](.attachments.136930/1464-316-max%20%282%29.png)
+
+    -   then check the /config/config.php on the nextcloud container for the following entries:
+
+        ![Expected entries in config.php](.attachments.136930/image%20%283%29.png)
+
+    -   If entries are missing (namely that identify the dbhost, dbuser, dbpassword etc), then this could be due to Windows build process not being able to read the \\.env file in the docker-compose.yaml file. The cause of this is unknown. As a workaround, it is good practice to set the default value of environment variables inside the docker-compose (and not rely on the settings defined in \\.env file) eg:
+
+    ![NC_VERSION default value is set in the docker-compose](.attachments.136930/image%20%284%29.png)
+
+    -   Note: After any changes to docker-compose, remember to rebuild the docker-compose:
+        -   docker-compose --profile dev up -d --force-recreate --remove-orphans --build
+
+##### Known issue: Local path containimng NC source code has folder(s) with special character.
+
+When the docker-compose copies the NC source code to the local Windows path, there is a known issue with a folder containing a special character, eg:
+
+![Invalid Folder with special character](.attachments.136930/image%20%285%29.png)
+
+The cause of this incorrect folder is unknown. The impact is that it could prevent xDebug from working because it cannot find the local source code.
+
+To correct this issue , the easiest workaround is to rename the incorrect folder with a valid name, eg code. and then change the PathMapping setting in the \\.vscode\\launch.json file:
+
+![Ensure the /var/www/html path maps correctly to the local sourcecode](.attachments.136930/image%20%286%29.png)

--- a/cli/dev/windows/README.md
+++ b/cli/dev/windows/README.md
@@ -12,17 +12,17 @@ After running the \\cli\\dev\\windows\\clean.bat and start.bat files (which remo
 
     or
 
--   returns the error "base table or view not found: 1146 Table 'nextcloud.oc_appconfig' doesn't exist":
+    returns the error "base table or view not found: 1146 Table 'nextcloud.oc_appconfig' doesn't exist":
+  
+    ![missing tables in nextcloud database](https://github.com/user-attachments/assets/e0c12d9f-427c-45ce-ad5b-4ca675bbe4f3)
 
-    ![Error: missing tables in nextcloud database](.attachments.136930/1464-316-max%20%282%29.png)
-
-    -   then check the /config/config.php on the nextcloud container for the following entries:
-
-        ![Expected entries in config.php](.attachments.136930/image%20%283%29.png)
+-   then check the /config/config.php on the nextcloud container for the following entries:
+    
+    Expected entries in config.php](https://github.com/user-attachments/assets/de1a11a3-3749-469e-9502-3a05fc3e4d9f)
 
     -   If entries are missing (namely that identify the dbhost, dbuser, dbpassword etc), then this could be due to Windows build process not being able to read the \\.env file in the docker-compose.yaml file. The cause of this is unknown. As a workaround, it is good practice to set the default value of environment variables inside the docker-compose (and not rely on the settings defined in \\.env file) eg:
-
-    ![NC_VERSION default value is set in the docker-compose](.attachments.136930/image%20%284%29.png)
+      
+    ![NC_VERSION default value is set in the docker-compose](https://github.com/user-attachments/assets/3492e330-081d-41fa-b3ab-b912a17e632a)
 
     -   Note: After any changes to docker-compose, remember to rebuild the docker-compose:
         -   docker-compose --profile dev up -d --force-recreate --remove-orphans --build
@@ -31,10 +31,10 @@ After running the \\cli\\dev\\windows\\clean.bat and start.bat files (which remo
 
 When the docker-compose copies the NC source code to the local Windows path, there is a known issue with a folder containing a special character, eg:
 
-![Invalid Folder with special character](.attachments.136930/image%20%285%29.png)
+![Invalid Folder with special character](https://github.com/user-attachments/assets/df0e231c-4406-4c94-8064-596af47cf888)
 
 The cause of this incorrect folder is unknown. The impact is that it could prevent xDebug from working because it cannot find the local source code.
 
 To correct this issue , the easiest workaround is to rename the incorrect folder with a valid name, eg code. and then change the PathMapping setting in the \\.vscode\\launch.json file:
 
-![Ensure the /var/www/html path maps correctly to the local sourcecode](.attachments.136930/image%20%286%29.png)
+![Ensure the /var/www/html path maps correctly to the local sourcecode](https://github.com/user-attachments/assets/a75626a3-5a72-4795-b850-00cb6bfea5ce)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: ./docker/nextcloud
       dockerfile: Dockerfile
       args:
-        NC_VERSION: ${NC_VERSION:-28}
+        NC_VERSION: ${NC_VERSION:-29}
       target: ${ENV:-development}
     restart: unless-stopped
     depends_on:
@@ -28,7 +28,7 @@ services:
       redis:
         condition: service_healthy
     env_file:
-      - .env
+      - .\.env
     environment:
       MYSQL_HOST: mariadb:3306
       REDIS_HOST: redis
@@ -45,7 +45,7 @@ services:
       - ./:/var/www/html/custom_apps/files_external_ethswarm
 
   cron:
-    image: nextcloud:${NC_VERSION:-28}-fpm-alpine
+    image: nextcloud:${NC_VERSION:-29}-fpm-alpine
     restart: always
     volumes:
       - nc-app:/var/www/html:z


### PR DESCRIPTION
bugfix: Correction to docker-compose for Windows installations
- add: updated default values of environment variables in docker-compose (in case the .env file is not read)
- add: README documentation for known issues
