### PR TITLE
feat(docker): add install ocs api viewer app

### DIFF
--- a/docker/nextcloud/hooks/post-installation/004-install-ocs-api-viewer.sh
+++ b/docker/nextcloud/hooks/post-installation/004-install-ocs-api-viewer.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+php occ app:install ocs_api_viewer


### PR DESCRIPTION
This pull request includes a new script to automate the installation of the `ocs_api_viewer` app for Nextcloud.

* [`docker/nextcloud/hooks/post-installation/004-install-ocs-api-viewer.sh`](diffhunk://#diff-15644e6df0d5a6a23c78de763a8ce86abaebc3714f96007c3e3e22ce5a8c2f38R1-R4): Added a new shell script to automatically install the `ocs_api_viewer` app using the `php occ app:install` command.