### PR TITLE
bugfix: exception handling to ensure the response is handled correctly

### DIFF
--- a/lib/Storage/BeeSwarmTrait.php
+++ b/lib/Storage/BeeSwarmTrait.php
@@ -26,8 +26,8 @@ use OCA\Files_External_Ethswarm\Auth\License;
 use OCA\Files_External_Ethswarm\Backend\BeeSwarm;
 use OCA\Files_External_Ethswarm\Exception\SwarmException;
 use OCA\Files_External_Ethswarm\Utils\Curl;
-use OCP\Files\StorageNotAvailableException;
 use OCP\Files\StorageBadConfigException;
+use OCP\Files\StorageNotAvailableException;
 use Safe\Exceptions\CurlException;
 
 trait BeeSwarmTrait {

--- a/lib/Storage/BeeSwarmTrait.php
+++ b/lib/Storage/BeeSwarmTrait.php
@@ -170,9 +170,9 @@ trait BeeSwarmTrait {
 		if (!$curl->isResponseSuccessful()) {
 			if (401 === $statusCode) {
 				throw new StorageNotAvailableException('Invalid access key');
-			} else {
-				throw new StorageNotAvailableException('Failed to connect to HejBit');
 			}
+
+			throw new StorageNotAvailableException('Failed to connect to HejBit');
 		}
 
 		if (204 !== $statusCode) {

--- a/lib/Storage/BeeSwarmTrait.php
+++ b/lib/Storage/BeeSwarmTrait.php
@@ -26,6 +26,7 @@ use OCA\Files_External_Ethswarm\Auth\License;
 use OCA\Files_External_Ethswarm\Backend\BeeSwarm;
 use OCA\Files_External_Ethswarm\Exception\SwarmException;
 use OCA\Files_External_Ethswarm\Utils\Curl;
+use OCP\Files\StorageNotAvailableException;
 use OCP\Files\StorageBadConfigException;
 use Safe\Exceptions\CurlException;
 
@@ -163,13 +164,13 @@ trait BeeSwarmTrait {
 		$endpoint = $this->api_url.'/api/readiness';
 
 		$curl = new Curl($endpoint, authorization: $this->access_key);
-		$response = $curl->exec(true);
+		$response = $curl->exec();
 
-		if (!$curl->isResponseSuccessful() and !isset($response['status'])) {
-			throw new SwarmException('Failed to connect to HejBit: '.$response['message']);
+		if (!$curl->isResponseSuccessful()) {
+			throw new StorageNotAvailableException('Failed to connect to HejBit');
 		}
 
-		return 'ok' === $response['status'];
+		return '{"status":"ok"}' === $response;
 	}
 
 	/**

--- a/lib/Utils/Curl.php
+++ b/lib/Utils/Curl.php
@@ -65,11 +65,11 @@ class Curl {
 	 * @throws CurlException
 	 */
 	public function isResponseSuccessful(): bool {
-		if (0 === $this->getInfo(CURLINFO_HTTP_CODE)) {
+		if (0 === $this->getStatusCode()) {
 			throw new CurlException('Curl handler has not been executed');
 		}
 
-		return 200 === $this->getInfo(CURLINFO_HTTP_CODE) || 201 === $this->getInfo(CURLINFO_HTTP_CODE);
+		return $this->getStatusCode() < 400;
 	}
 
 	private static function getDefaultOptions(): array {
@@ -124,5 +124,9 @@ class Curl {
 
 			throw new CurlException(curl_error($this->handler));
 		}
+	}
+
+	public function getStatusCode(): int {
+		return $this->getInfo(CURLINFO_HTTP_CODE);
 	}
 }

--- a/lib/Utils/Curl.php
+++ b/lib/Utils/Curl.php
@@ -72,6 +72,10 @@ class Curl {
 		return $this->getStatusCode() < 400;
 	}
 
+	public function getStatusCode(): int {
+		return $this->getInfo(CURLINFO_HTTP_CODE);
+	}
+
 	private static function getDefaultOptions(): array {
 		return self::checkSSLOption() + self::DEFAULT_OPTIONS;
 	}
@@ -124,9 +128,5 @@ class Curl {
 
 			throw new CurlException(curl_error($this->handler));
 		}
-	}
-
-	public function getStatusCode(): int {
-		return $this->getInfo(CURLINFO_HTTP_CODE);
 	}
 }


### PR DESCRIPTION
This PR aims to correct a bug when setting up a new HejBit External Storage with incorrect configuration(s) on NC Administration Settings. 

### Notes:
- An incorrect configuration can be an invalid Server URL or an invalid Access Key;
- For every attempt that fails the connection test, a duplicate of the storage is created (which then appear when the browser page is reloaded - This is due to the exception handling of the response from the hejbit api call `/readiness`

### Changes:
- update: do not assume an array (json) response from the api. The response is not always json which causes the `json_decode()` to return `null` (which being an invalid return value causes the `test()` function to fail its return value);
- add: `StorageNotAvailableException` to ensure a user-friendly error message on the front-end;
- update: return value can be a string