### PR TITLE
feat(toast): add nextcloud dialogs

### DIFF
--- a/img/swarm-logo.svg
+++ b/img/swarm-logo.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100.3 100.3" style="enable-background:new 0 0 100.3 100.3;" xml:space="preserve">
 <style type="text/css">

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@ethersphere/bee-js": "^3.3.3",
 				"@material-design-icons/svg": "^0.14.13",
 				"@nextcloud/axios": "^2.5.1",
+				"@nextcloud/dialogs": "^3.1.2",
 				"@nextcloud/event-bus": "^3.3.1",
 				"@nextcloud/files": "^3.6.0",
 				"@nextcloud/router": "^2.0.0",
@@ -2198,6 +2199,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-3.1.2.tgz",
 			"integrity": "sha512-hVgpr/CF0F+cE7tRZHJDVpB1S05K/pDcUMrfDpoxMKhux5SXlpwLXUaWM7iAbHEKYm6ArWdpUyhxBTTAo9yrvg==",
+			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/l10n": "^1.3.0",
 				"@nextcloud/typings": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"@ethersphere/bee-js": "^3.3.3",
 		"@material-design-icons/svg": "^0.14.13",
 		"@nextcloud/axios": "^2.5.1",
+		"@nextcloud/dialogs": "^3.1.2",
 		"@nextcloud/event-bus": "^3.3.1",
 		"@nextcloud/files": "^3.6.0",
 		"@nextcloud/router": "^2.0.0",


### PR DESCRIPTION
This pull request includes several changes to the `src/fileactions.js` file and a minor addition to the `package.json` file. The changes primarily focus on improving code consistency, updating deprecated methods, and enhancing user interaction with file actions.

### Code Consistency and Formatting:
* Standardized the use of double quotes for strings and adjusted indentation and spacing for better readability in `src/fileactions.js`. [[1]](diffhunk://#diff-1b35e833adcf1267010e489a7b9fbfeff59fa74a6d609a864797361d64a9a5eeL42-R375) [[2]](diffhunk://#diff-1b35e833adcf1267010e489a7b9fbfeff59fa74a6d609a864797361d64a9a5eeL337-R390) [[3]](diffhunk://#diff-1b35e833adcf1267010e489a7b9fbfeff59fa74a6d609a864797361d64a9a5eeL348-R468) [[4]](diffhunk://#diff-1b35e833adcf1267010e489a7b9fbfeff59fa74a6d609a864797361d64a9a5eeL434-R485) [[5]](diffhunk://#diff-1b35e833adcf1267010e489a7b9fbfeff59fa74a6d609a864797361d64a9a5eeL446-L464)

### Dependency Updates:
* Added `@nextcloud/dialogs` version `^3.1.2` to the `package.json` file.

### Deprecated Methods:
* Updated comments to indicate the deprecation of `OC.dialogs.confirm` in Nextcloud 31.

### User Interaction Enhancements:
* Replaced `OC.dialogs.info` with `showInfo`, `showSuccess`, and `showWarning` from `@nextcloud/dialogs` for better user notifications.

### Functional Improvements:
* Improved the `exec` method for file actions to provide better feedback when copying Swarm references and handling file visibility changes.