### PR TITLE
Feature/docker composer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       redis:
         condition: service_healthy
     env_file:
-      - .\.env
+      - .env
     environment:
       MYSQL_HOST: mariadb:3306
       REDIS_HOST: redis

--- a/docker/nextcloud/Dockerfile
+++ b/docker/nextcloud/Dockerfile
@@ -24,6 +24,7 @@ COPY --chown=www-data ./hooks /docker-entrypoint-hooks.d
 FROM base AS development
 
 RUN apk add --update --no-cache linux-headers $PHPIZE_DEPS;
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer;
 RUN pecl install xdebug && docker-php-ext-enable xdebug;
 RUN { \
 	echo "xdebug.mode=develop,debug"; \


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` and `docker/nextcloud/Dockerfile` files to improve environment configuration and add Composer installation.

Improvements to environment configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L31-R31): Fixed the path in the `env_file` directive by removing the backslash. Although it might be needed is some Windows' installation we need the docker compose to work with stage deployment automations thus we need to support Linux first.  

Enhancements to Dockerfile:

* [`docker/nextcloud/Dockerfile`](diffhunk://#diff-efef6090a4039b2c874e0fdc8f4c0eb21fb4e08f54dcd18f6f859c287dcbf259R27): Added a command to install Composer globally in the Docker image.