### PR TITLE
fix(storage): remove type to support NC29+NC30

### DIFF
--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -52,7 +52,7 @@ use Traversable;
 class BeeSwarm extends Common implements IBeeSwarm {
 	use BeeSwarmTrait;
 
-	public const string ARCHIVE_FOLDER = 'Archive - HejBit';
+	public const ARCHIVE_FOLDER = 'Archive - HejBit';
 
 	protected IDBConnection $dbConnection;
 


### PR DESCRIPTION
This PR fixes a syntax error in BeeSwarm.php by removing the invalid type declaration from the class constant.

Details
• Removed the string type declaration from the ARCHIVE_FOLDER constant.
• This change makes it compatible with PHP versions before 8.3, where typed class constants aren’t supported.
• Nextcloud 29 and 30 both run on PHP 8.2, so this fixes compatibility issues with those versions.