### PR TITLE
Sentry improvements

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -36,14 +36,14 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Exceptions\AppConfigException;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Sentry;
 
-class Application extends App implements IBootstrap
-{
+class Application extends App implements IBootstrap {
 	public const NAME = 'files_external_ethswarm';
 	public const API_URL = 'app.hejbit.com';
 	public const TELEMETRY_URL = 'https://c46a60056f22db1db257c1d99fa99e5f@sentry.metaprovide.org/2';
@@ -57,8 +57,7 @@ class Application extends App implements IBootstrap
 	/**
 	 * @throws AppConfigException
 	 */
-	public function __construct()
-	{
+	public function __construct() {
 		parent::__construct(Application::NAME);
 		$this->logger = $this->getContainer()->get(LoggerInterface::class);
 		$this->config = $this->getContainer()->get(IConfig::class);
@@ -67,16 +66,14 @@ class Application extends App implements IBootstrap
 		$this->enableFilesExternalApp();
 	}
 
-	public function boot(IBootContext $context): void
-	{
+	public function boot(IBootContext $context): void {
 		new ExternalStorage($this->getContainer(), $context);
 
 		$this->loadAssets($context);
 		$this->configureTelemetry();
 	}
 
-	public function register(IRegistrationContext $context): void
-	{
+	public function register(IRegistrationContext $context): void {
 		$this->loadTelemetry();
 
 		$this->dispatcher->addListener(
@@ -95,8 +92,7 @@ class Application extends App implements IBootstrap
 	/**
 	 * @throws AppConfigException
 	 */
-	private function enableFilesExternalApp(): void
-	{
+	private function enableFilesExternalApp(): void {
 		/** @var IAppManager $appManager */
 		$appManager = $this->getContainer()->get(IAppManager::class);
 		if (!$appManager->isInstalled('files_external')) {
@@ -123,8 +119,7 @@ class Application extends App implements IBootstrap
 		}
 	}
 
-	private function loadAssets($context): void
-	{
+	private function loadAssets($context): void {
 		Util::addStyle(Application::NAME, 'app');
 		Util::addScript(Application::NAME, 'nextcloud-swarm-plugin-settings');
 
@@ -136,19 +131,17 @@ class Application extends App implements IBootstrap
 		});
 	}
 
-	private function loadTelemetry(): void
-	{
+	private function loadTelemetry(): void {
 		// Register autoloader of sentry
-		$autoloadPath = __DIR__ . '/../../vendor-bin/sentry/vendor/autoload.php';
+		$autoloadPath = __DIR__.'/../../vendor-bin/sentry/vendor/autoload.php';
 		if (!file_exists($autoloadPath)) {
-			throw new BaseException('Vendor autoload.php not found at: ' . $autoloadPath);
+			throw new BaseException('Vendor autoload.php not found at: '.$autoloadPath);
 		}
 
 		require_once $autoloadPath;
 	}
 
-	private function configureTelemetry(): void
-	{
+	private function configureTelemetry(): void {
 		// Initialize Sentry if telemetry is enabled and the nextcloud version is supported
 		$environment = Env::get('ENV') ?? 'production';
 
@@ -169,8 +162,8 @@ class Application extends App implements IBootstrap
 			$appInfo = $appManager->getAppInfo(self::NAME);
 			$pluginVersion = $appInfo['version'] ?? 'unknown';
 
-			/** @var \OCP\IURLGenerator $urlGenerator */
-			$urlGenerator = $this->getContainer()->get(\OCP\IURLGenerator::class);
+			/** @var IURLGenerator $urlGenerator */
+			$urlGenerator = $this->getContainer()->get(IURLGenerator::class);
 			$instanceUrl = $urlGenerator->getAbsoluteURL('/');
 
 			Sentry\init([
@@ -189,7 +182,7 @@ class Application extends App implements IBootstrap
 
 			$this->logger->info('Telemetry is enabled and the nextcloud version is supported');
 		} elseif ($this->config->getSystemValue('telemetry.enabled') && !$isSupported) {
-			$this->logger->info('Telemetry is enabled but the nextcloud version ' . $currentNextcloudVersion . ' is not supported');
+			$this->logger->info('Telemetry is enabled but the nextcloud version '.$currentNextcloudVersion.' is not supported');
 		} elseif (false === $this->config->getSystemValue('telemetry.enabled')) {
 			$this->logger->info('Telemetry is disabled');
 		}

--- a/lib/Exception/BaseException.php
+++ b/lib/Exception/BaseException.php
@@ -7,10 +7,8 @@ use OC;
 use OCP\IConfig;
 use Sentry;
 
-class BaseException extends Exception
-{
-	public function __construct($message, $code = 0, ?Exception $previous = null)
-	{
+class BaseException extends Exception {
+	public function __construct($message, $code = 0, ?Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 
 		// Report exception to Sentry if enabled


### PR DESCRIPTION
This PR restricts Sentry to capture only events based from BaseException.php. Thus removing unnecessary reporting. 

In addition 3 new tags have been included:
- server_name (aka instance url)
- release (aka plugin version)
- nextcloud_version