### PR TITLE
Fix/copy swarm file

### DIFF
--- a/lib/Db/SwarmFile.php
+++ b/lib/Db/SwarmFile.php
@@ -26,8 +26,6 @@ namespace OCA\Files_External_Ethswarm\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method void        setFileId(int $fileId)
- * @method int         getFileId()
  * @method void        setName(string $name)
  * @method string      getName()
  * @method void        setSwarmReference(string $swarmReference)
@@ -50,9 +48,6 @@ use OCP\AppFramework\Db\Entity;
  * @method int         getToken()
  */
 class SwarmFile extends Entity {
-	/** @var null|int */
-	protected $fileId;
-
 	/** @var string */
 	protected $name;
 
@@ -84,7 +79,6 @@ class SwarmFile extends Entity {
 	protected $token;
 
 	public function __construct() {
-		$this->addType('fileId', 'int');
 		$this->addType('name', 'string');
 		$this->addType('swarmReference', 'string');
 		$this->addType('swarmTag', 'string');

--- a/lib/Db/SwarmFileMapper.php
+++ b/lib/Db/SwarmFileMapper.php
@@ -44,13 +44,13 @@ class SwarmFileMapper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
-	public function findByFileId(string $fileId): ?SwarmFile {
+	public function findById(string $id): ?SwarmFile {
 		$qb = $this->db->getQueryBuilder();
 
 		$select = $qb
 			->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('fileId', $qb->createNamedParameter($fileId)))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 		;
 
 		return $this->findEntities($select)[0] ?? null;

--- a/lib/Service/EthswarmService.php
+++ b/lib/Service/EthswarmService.php
@@ -74,8 +74,8 @@ class EthswarmService {
 		return $this->fileMapper->update($swarmFile);
 	}
 
-	public function getToken(string $fileId): string {
-		$swarmFile = $this->fileMapper->findByFileId($fileId);
+	public function getToken(string $id): string {
+		$swarmFile = $this->fileMapper->findById($id);
 		if (!$swarmFile) {
 			throw new StorageNotAvailableException($this->l10n->t('No token found'));
 		}

--- a/lib/Storage/BeeSwarm.php
+++ b/lib/Storage/BeeSwarm.php
@@ -158,7 +158,7 @@ class BeeSwarm extends Common implements IBeeSwarm {
 		try {
 			// Get the source file from the mapper
 			$sourceFile = $this->fileMapper->find($source, $this->storageId);
-			if (!$sourceFile->getFileId()) {
+			if (!$sourceFile->getId()) {
 				$this->logger->error(
 					'copy failed: source file not found in mapper '.$source,
 					['app' => Application::NAME]
@@ -177,11 +177,12 @@ class BeeSwarm extends Common implements IBeeSwarm {
 			$copyData['storage_mtime'] = time();
 			$copyData['storage'] = $this->storageId;
 			$copyData['token'] = $this->token;
+			$copyData['visibility'] = $sourceFile->getVisibility();
 
 			// Create the new file entry in the mapper
 			$newFile = $this->fileMapper->createFile($copyData);
 
-			if (!$newFile->getFileId()) {
+			if (!$newFile->getId()) {
 				$this->logger->error(
 					'copy failed: failed to create new file in mapper '.$target,
 					['app' => Application::NAME]

--- a/vendor-bin/sentry/composer.lock
+++ b/vendor-bin/sentry/composer.lock
@@ -386,16 +386,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "4.13.0",
+            "version": "4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "b54a0eaedfc27fc2da587e64455a66cd29cd3c4d"
+                "reference": "f8c50304bd2f1640704345274bdd5af150b6945d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/b54a0eaedfc27fc2da587e64455a66cd29cd3c4d",
-                "reference": "b54a0eaedfc27fc2da587e64455a66cd29cd3c4d",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/f8c50304bd2f1640704345274bdd5af150b6945d",
+                "reference": "f8c50304bd2f1640704345274bdd5af150b6945d",
                 "shasum": ""
             },
             "require": {
@@ -459,7 +459,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.13.0"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.14.0"
             },
             "funding": [
                 {
@@ -471,7 +471,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-06-10T15:39:27+00:00"
+            "time": "2025-06-13T17:22:57+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
This pull request refactors the `SwarmFile` entity and its associated mapper and services, replacing the `fileId` property with `id` for consistency and simplifying the codebase. The changes span several files, including updates to method names, property definitions, and logic adjustments to align with the new naming convention.

### Refactoring of `SwarmFile` Entity:

* Removed the `fileId` property and its associated getter and setter methods from `SwarmFile`. Updated the constructor to exclude the `fileId` type definition. (`lib/Db/SwarmFile.php`: [[1]](diffhunk://#diff-b6b5a65898b86551af675ef7c8a6a352005ac2ead7807caddcf6f86687fbda6bL29-L30) [[2]](diffhunk://#diff-b6b5a65898b86551af675ef7c8a6a352005ac2ead7807caddcf6f86687fbda6bL53-L55) [[3]](diffhunk://#diff-b6b5a65898b86551af675ef7c8a6a352005ac2ead7807caddcf6f86687fbda6bL87)

### Updates to `SwarmFileMapper`:

* Renamed the `findByFileId` method to `findById` and updated the query logic to use `id` instead of `fileId`. (`lib/Db/SwarmFileMapper.php`: [lib/Db/SwarmFileMapper.phpL47-R53](diffhunk://#diff-2a13e75b66c849766d074bae16ee795c7ad462e0ded0d7475a1fcc552aef41adL47-R53))

### Adjustments in Service and Storage Logic:

* Updated the `getToken` method in `EthswarmService` to use `findById` instead of `findByFileId`. (`lib/Service/EthswarmService.php`: [lib/Service/EthswarmService.phpL77-R78](diffhunk://#diff-c054234b648d729ef4073bd2f24215644cf135691b4430da5bb5e186e848f8e5L77-R78))
* Modified the `copy` method in `BeeSwarm` to use `getId` instead of `getFileId` and added support for copying the `visibility` property from the source file to the new file entry. (`lib/Storage/BeeSwarm.php`: [[1]](diffhunk://#diff-94acfeab684018436a67c624d93440c03e12d6d27e43b7275e91f59449292931L161-R161) [[2]](diffhunk://#diff-94acfeab684018436a67c624d93440c03e12d6d27e43b7275e91f59449292931R180-R185)