### PR TITLE
Release 1.0.2: #154

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 ENV=development
-NC_VERSION=30
+NC_VERSION=31
 APP_URL=localhost
 API_URL=https://hejbit.local
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin integrates [Swarm](https://www.ethswarm.org/) (a decentralized, bloc
 
 Before using the plugin, ensure you have the following:
 
--   An active Nextcloud instance (version 30, 31 or 32)
+-   An active Nextcloud instance (version 31 or 32)
 -   A valid Access Key and URL to activate the service
     -   [Get Your Free Trial for the Nextcloud Swarm Plugin](https://app.hejbit.com)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ This plugin integrates [Swarm](https://www.ethswarm.org/) (a decentralized, bloc
 
 Before using the plugin, ensure you have the following:
 
-- An active Nextcloud instance (version 30, 31 or 32)
+- An active Nextcloud instance (version 31 or 32)
 - A valid Access Key and URL to activate the service
   - [Get Your Free Trial for the Nextcloud Swarm Plugin](https://app.hejbit.com)
 
@@ -89,7 +89,7 @@ Experience the future of data storage with 5GB of free, decentralized storage on
 This program is licensed under the AGPLv3 or later.
 
     ]]></description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <licence>agpl</licence>
     <author>MetaProvide</author>
     <namespace>Files_External_Ethswarm</namespace>
@@ -104,7 +104,7 @@ This program is licensed under the AGPLv3 or later.
     <repository type="git">https://github.com/MetaProvide/nextcloud-swarm-plugin.git</repository>
 	<screenshot>https://raw.githubusercontent.com/MetaProvide/nextcloud-swarm-plugin/main/assets/images/swarm_Files.png</screenshot>
     <dependencies>
-        <nextcloud min-version="30" max-version="32"/>
+        <nextcloud min-version="31" max-version="32"/>
     </dependencies>
 	<settings>
 		<admin>OCA\Files_External_Ethswarm\Settings\Admin</admin>

--- a/lib/AppInfo/Telemetry.php
+++ b/lib/AppInfo/Telemetry.php
@@ -12,7 +12,7 @@ use Sentry\State;
 
 trait Telemetry {
 	public const TELEMETRY_URL = 'https://c46a60056f22db1db257c1d99fa99e5f@sentry.metaprovide.org/2';
-	public const TELEMETRY_MINIMUM_SUPPORTED_NEXTCLOUD_VERSION = '30.0.0';
+	public const TELEMETRY_MINIMUM_SUPPORTED_NEXTCLOUD_VERSION = '31.0.0';
 
 	protected function loadTelemetry(): void {
 		// Register autoloader of sentry

--- a/vendor-bin/sentry/composer.lock
+++ b/vendor-bin/sentry/composer.lock
@@ -386,16 +386,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "4.17.0",
+            "version": "4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "62927369a572efc27ddbd89e466e17788329224b"
+                "reference": "5c696b8de57e841a2bf3b6f6eecfd99acfdda80c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/62927369a572efc27ddbd89e466e17788329224b",
-                "reference": "62927369a572efc27ddbd89e466e17788329224b",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5c696b8de57e841a2bf3b6f6eecfd99acfdda80c",
+                "reference": "5c696b8de57e841a2bf3b6f6eecfd99acfdda80c",
                 "shasum": ""
             },
             "require": {
@@ -458,7 +458,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.17.0"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.17.1"
             },
             "funding": [
                 {
@@ -470,7 +470,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-10-20T12:57:02+00:00"
+            "time": "2025-10-23T15:19:24+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
This PR removes compatibility with Nextcloud 30, preparing the codebase for full support of Nextcloud 31+ and ensuring forward maintenance stability.
All outdated or deprecated compatibility code paths have been cleaned up, resulting in a more streamlined and maintainable codebase.

### Changes

- Dropped Nextcloud 30 compatibility.
- Applied minor code style fixes for consistency.
- Co-authored by @JoaoSRaposo.

### Rationale

Nextcloud 30 reached its end of active support, and maintaining backward compatibility was adding unnecessary complexity.
This update allows the project to align with current Nextcloud core APIs and dependencies.

### Testing

- Verified build and integration with NC 31.
- Confirmed no breaking changes for NC 31+ users.

### Linked Issue

Closes #154