### PR TITLE
fix: normalize host URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # OS
 .DS_Store
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+/graft/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# graft's cards are gitignored but should stay greppable: ripgrep reads
+# .ignore before .gitignore, so this re-admits the tree to search only.
+!graft/
+graft/.cache/
+graft/.graph/

--- a/lib/Utils/HostUrl.php
+++ b/lib/Utils/HostUrl.php
@@ -6,7 +6,7 @@ namespace OCA\Files_External_Ethswarm\Utils;
 
 final class HostUrl {
 	public static function normalize(string $hostUrl): ?string {
-		$normalizedHostUrl = trim($hostUrl);
+		$normalizedHostUrl = rtrim(trim($hostUrl), '/');
 
 		if ('' === $normalizedHostUrl) {
 			return null;

--- a/tests/Unit/HostUrlTest.php
+++ b/tests/Unit/HostUrlTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OCA\Files_External_Ethswarm\Tests\Unit;
+
+use OCA\Files_External_Ethswarm\Utils\HostUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \OCA\Files_External_Ethswarm\Utils\HostUrl
+ */
+class HostUrlTest extends TestCase {
+	public function testNormalizeRemovesTrailingSlashes(): void {
+		$this->assertSame('https://auth.example', HostUrl::normalize('auth.example///'));
+	}
+}


### PR DESCRIPTION
## Summary
- remove trailing slashes from normalized host URLs so API paths are constructed correctly
- add a regression test for trailing-slash host URLs
- add the graft project cache configuration

## Verification
- php syntax checks
- direct readiness URL construction check